### PR TITLE
feat/team-detail-page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,8 @@ import { orderBy } from "lodash";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import Table from "./shared/components/Table";
+import { getLogoByTeamName } from "./shared/constants/logo";
+import { Team } from "~/keelClient";
 
 const keelClient = getKeelServer();
 
@@ -14,8 +16,6 @@ export default async function Home() {
     ? orderBy(teams?.data?.results, ["name"], ["asc"])
     : [];
 
-  console.log(teams);
-
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <TeamList teams={orderedTeams} />
@@ -23,79 +23,16 @@ export default async function Home() {
   );
 }
 
-const TeamLogos = {
-  "Atlanta Hawks":
-    "https://upload.wikimedia.org/wikipedia/en/2/24/Atlanta_Hawks_logo.svg",
-  "Boston Celtics":
-    "https://upload.wikimedia.org/wikipedia/en/8/8f/Boston_Celtics.svg",
-  "Brooklyn Nets":
-    "https://upload.wikimedia.org/wikipedia/commons/4/44/Brooklyn_Nets_newlogo.svg",
-  "Charlotte Hornets":
-    "https://upload.wikimedia.org/wikipedia/en/c/c4/Charlotte_Hornets_%282014%29.svg",
-  "Chicago Bulls":
-    "https://upload.wikimedia.org/wikipedia/en/6/67/Chicago_Bulls_logo.svg",
-  "Cleveland Cavaliers":
-    "https://upload.wikimedia.org/wikipedia/commons/4/4b/Cleveland_Cavaliers_logo.svg",
-  "Dallas Mavericks":
-    "https://upload.wikimedia.org/wikipedia/en/9/97/Dallas_Mavericks_logo.svg",
-  "Denver Nuggets":
-    "https://upload.wikimedia.org/wikipedia/en/7/76/Denver_Nuggets.svg",
-  "Detroit Pistons":
-    "https://upload.wikimedia.org/wikipedia/commons/c/c9/Logo_of_the_Detroit_Pistons.svg",
-  "Golden State Warriors":
-    "https://upload.wikimedia.org/wikipedia/en/0/01/Golden_State_Warriors_logo.svg",
-  "Houston Rockets":
-    "https://upload.wikimedia.org/wikipedia/en/2/28/Houston_Rockets.svg",
-  "Indiana Pacers":
-    "https://upload.wikimedia.org/wikipedia/en/1/1b/Indiana_Pacers.svg",
-  "LA Clippers":
-    "https://upload.wikimedia.org/wikipedia/en/b/bb/Los_Angeles_Clippers_%282015%29.svg",
-  "Los Angeles Lakers":
-    "https://upload.wikimedia.org/wikipedia/commons/3/3c/Los_Angeles_Lakers_logo.svg",
-  "Memphis Grizzlies":
-    "https://upload.wikimedia.org/wikipedia/en/f/f1/Memphis_Grizzlies.svg",
-  "Miami Heat":
-    "https://upload.wikimedia.org/wikipedia/en/f/fb/Miami_Heat_logo.svg",
-  "Milwaukee Bucks":
-    "https://upload.wikimedia.org/wikipedia/en/4/4a/Milwaukee_Bucks_logo.svg",
-  "Minnesota Timberwolves":
-    "https://upload.wikimedia.org/wikipedia/en/c/c2/Minnesota_Timberwolves_logo.svg",
-  "New Orleans Pelicans":
-    "https://upload.wikimedia.org/wikipedia/en/0/0d/New_Orleans_Pelicans_logo.svg",
-  "New York Knicks":
-    "https://upload.wikimedia.org/wikipedia/en/2/25/New_York_Knicks_logo.svg",
-  "Oklahoma City Thunder":
-    "https://upload.wikimedia.org/wikipedia/en/5/5d/Oklahoma_City_Thunder.svg",
-  "Orlando Magic":
-    "https://upload.wikimedia.org/wikipedia/en/1/10/Orlando_Magic_logo.svg",
-  "Philadelphia 76ers":
-    "https://upload.wikimedia.org/wikipedia/en/0/0e/Philadelphia_76ers_logo.svg",
-  "Phoenix Suns":
-    "https://upload.wikimedia.org/wikipedia/en/d/dc/Phoenix_Suns_logo.svg",
-  "Portland Trail Blazers":
-    "https://upload.wikimedia.org/wikipedia/commons/3/33/Portland-Trail-Blazers-Logo-2002.png",
-  "Sacramento Kings":
-    "https://upload.wikimedia.org/wikipedia/en/c/c7/SacramentoKings.svg",
-  "San Antonio Spurs":
-    "https://upload.wikimedia.org/wikipedia/en/a/a2/San_Antonio_Spurs.svg",
-  "Toronto Raptors":
-    "https://upload.wikimedia.org/wikipedia/en/3/36/Toronto_Raptors_logo.svg",
-  "Utah Jazz":
-    "https://upload.wikimedia.org/wikipedia/en/0/04/Utah_Jazz_logo_%282016%29.svg",
-  "Washington Wizards":
-    "https://upload.wikimedia.org/wikipedia/en/0/02/Washington_Wizards_logo.svg",
-};
-
 function TeamList({ teams }) {
-  const headers = ["Name", "Next Game", "Last Game", "Record"];
   const columns = [
     {
-      children: (info) => (
+      header: "Name",
+      getBody: (info: Team) => (
         <div className="flex items-center">
           <div className="flex-shrink-0 w-10 h-10">
             <Image
               className="w-full h-full rounded-full"
-              src={TeamLogos[info.name]}
+              src={getLogoByTeamName(info.name)}
               alt=""
               width={40}
               height={40}
@@ -106,13 +43,16 @@ function TeamList({ teams }) {
       ),
     },
     {
-      children: (info) => <div>Next game</div>,
+      header: "Next game",
+      getBody: (info: Team) => <div>Next game</div>,
     },
     {
-      children: (info) => <div>Last game</div>,
+      header: "Last game",
+      getBody: (info: Team) => <div>Last game</div>,
     },
     {
-      children: (info) => <div>Record</div>,
+      header: "Record",
+      getBody: (info: Team) => <div>Record</div>,
     },
   ];
 
@@ -124,7 +64,6 @@ function TeamList({ teams }) {
             <Table
               data={teams}
               columns={columns}
-              headers={headers}
               rowLink={(row) => `team/${row.id}`}
             />
           </div>

--- a/app/player/[id]/page.tsx
+++ b/app/player/[id]/page.tsx
@@ -1,0 +1,23 @@
+import Table from "~/app/shared/components/Table";
+import { getKeelServer } from "../../keel/server";
+import { DateTime } from "luxon";
+
+interface TeamPageProps {
+  params: { id: string };
+}
+
+const keelClient = getKeelServer();
+
+export default async function TeamPage({ params }: TeamPageProps) {
+  const { data: player, error } = await keelClient.getPlayer({ id: params.id });
+
+  if (error || !player) return <div>Player not found</div>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl">
+        {player.firstName} {player.lastName}
+      </h1>
+    </div>
+  );
+}

--- a/app/shared/components/Table.tsx
+++ b/app/shared/components/Table.tsx
@@ -1,21 +1,26 @@
 import Link from "next/link";
-
+import _ from "lodash";
 interface TableProps {
   data: Array<any>;
-  headers: Array<string>;
   columns: Array<{
     link?: string;
-    children: (info) => React.ReactNode;
+    header: string;
+    getBody: (info: any) => React.ReactNode;
   }>;
-  rowLink?: (rowInfo) => string;
+  rowLink?: (rowInfo: Record<string, unknown>) => string;
+  orderBy?: string | ((rowInfo: Record<string, unknown>) => string | number);
+  orderDir?: "asc" | "desc";
 }
 
 export default function Table({
   data,
-  headers,
   columns,
   rowLink = () => "#",
+  orderBy = "",
+  orderDir = "asc",
 }: TableProps) {
+  const headers = columns.map((column) => column.header);
+
   return (
     <table className="min-w-full leading-normal">
       <thead>
@@ -25,13 +30,13 @@ export default function Table({
               key={`${header}-${index}`}
               className="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider"
             >
-              Name
+              {header}
             </th>
           ))}
         </tr>
       </thead>
       <tbody>
-        {data.map((row, rIndex) => (
+        {_.orderBy(data, orderBy, orderDir).map((row, rIndex) => (
           <tr key={`row-${rIndex}`}>
             {columns.map((column, index) => (
               <td
@@ -39,7 +44,7 @@ export default function Table({
                 key={`column-${index}`}
               >
                 <Link href={column.link ?? rowLink(row)}>
-                  {column.children(row)}
+                  {column.getBody(row)}
                 </Link>
               </td>
             ))}

--- a/app/shared/constants/logo.ts
+++ b/app/shared/constants/logo.ts
@@ -1,0 +1,65 @@
+const TeamLogos = {
+  "Atlanta Hawks":
+    "https://upload.wikimedia.org/wikipedia/en/2/24/Atlanta_Hawks_logo.svg",
+  "Boston Celtics":
+    "https://upload.wikimedia.org/wikipedia/en/8/8f/Boston_Celtics.svg",
+  "Brooklyn Nets":
+    "https://upload.wikimedia.org/wikipedia/commons/4/44/Brooklyn_Nets_newlogo.svg",
+  "Charlotte Hornets":
+    "https://upload.wikimedia.org/wikipedia/en/c/c4/Charlotte_Hornets_%282014%29.svg",
+  "Chicago Bulls":
+    "https://upload.wikimedia.org/wikipedia/en/6/67/Chicago_Bulls_logo.svg",
+  "Cleveland Cavaliers":
+    "https://upload.wikimedia.org/wikipedia/commons/4/4b/Cleveland_Cavaliers_logo.svg",
+  "Dallas Mavericks":
+    "https://upload.wikimedia.org/wikipedia/en/9/97/Dallas_Mavericks_logo.svg",
+  "Denver Nuggets":
+    "https://upload.wikimedia.org/wikipedia/en/7/76/Denver_Nuggets.svg",
+  "Detroit Pistons":
+    "https://upload.wikimedia.org/wikipedia/commons/c/c9/Logo_of_the_Detroit_Pistons.svg",
+  "Golden State Warriors":
+    "https://upload.wikimedia.org/wikipedia/en/0/01/Golden_State_Warriors_logo.svg",
+  "Houston Rockets":
+    "https://upload.wikimedia.org/wikipedia/en/2/28/Houston_Rockets.svg",
+  "Indiana Pacers":
+    "https://upload.wikimedia.org/wikipedia/en/1/1b/Indiana_Pacers.svg",
+  "LA Clippers":
+    "https://upload.wikimedia.org/wikipedia/en/b/bb/Los_Angeles_Clippers_%282015%29.svg",
+  "Los Angeles Lakers":
+    "https://upload.wikimedia.org/wikipedia/commons/3/3c/Los_Angeles_Lakers_logo.svg",
+  "Memphis Grizzlies":
+    "https://upload.wikimedia.org/wikipedia/en/f/f1/Memphis_Grizzlies.svg",
+  "Miami Heat":
+    "https://upload.wikimedia.org/wikipedia/en/f/fb/Miami_Heat_logo.svg",
+  "Milwaukee Bucks":
+    "https://upload.wikimedia.org/wikipedia/en/4/4a/Milwaukee_Bucks_logo.svg",
+  "Minnesota Timberwolves":
+    "https://upload.wikimedia.org/wikipedia/en/c/c2/Minnesota_Timberwolves_logo.svg",
+  "New Orleans Pelicans":
+    "https://upload.wikimedia.org/wikipedia/en/0/0d/New_Orleans_Pelicans_logo.svg",
+  "New York Knicks":
+    "https://upload.wikimedia.org/wikipedia/en/2/25/New_York_Knicks_logo.svg",
+  "Oklahoma City Thunder":
+    "https://upload.wikimedia.org/wikipedia/en/5/5d/Oklahoma_City_Thunder.svg",
+  "Orlando Magic":
+    "https://upload.wikimedia.org/wikipedia/en/1/10/Orlando_Magic_logo.svg",
+  "Philadelphia 76ers":
+    "https://upload.wikimedia.org/wikipedia/en/0/0e/Philadelphia_76ers_logo.svg",
+  "Phoenix Suns":
+    "https://upload.wikimedia.org/wikipedia/en/d/dc/Phoenix_Suns_logo.svg",
+  "Portland Trail Blazers":
+    "https://upload.wikimedia.org/wikipedia/commons/3/33/Portland-Trail-Blazers-Logo-2002.png",
+  "Sacramento Kings":
+    "https://upload.wikimedia.org/wikipedia/en/c/c7/SacramentoKings.svg",
+  "San Antonio Spurs":
+    "https://upload.wikimedia.org/wikipedia/en/a/a2/San_Antonio_Spurs.svg",
+  "Toronto Raptors":
+    "https://upload.wikimedia.org/wikipedia/en/3/36/Toronto_Raptors_logo.svg",
+  "Utah Jazz":
+    "https://upload.wikimedia.org/wikipedia/en/0/04/Utah_Jazz_logo_%282016%29.svg",
+  "Washington Wizards":
+    "https://upload.wikimedia.org/wikipedia/en/0/02/Washington_Wizards_logo.svg",
+};
+
+export const getLogoByTeamName = (teamName: string): string =>
+  TeamLogos[teamName];

--- a/app/team/[id]/page.tsx
+++ b/app/team/[id]/page.tsx
@@ -1,6 +1,71 @@
+import Table from "~/app/shared/components/Table";
+import { getKeelServer } from "../../keel/server";
+import { DateTime } from "luxon";
+import { Player } from "~/keelClient";
+
 interface TeamPageProps {
   params: { id: string };
 }
-export default function TeamPage({ params }: TeamPageProps) {
-  return <div>{params.id}</div>;
+
+const keelClient = getKeelServer();
+
+export default async function TeamPage({ params }: TeamPageProps) {
+  const { data: team, error } = await keelClient.getTeam({ id: params.id });
+  const { data: playerList } = await keelClient.getPlayersOnTeam({
+    teamId: params.id,
+  });
+
+  if (error || !team) return <div>Team not found</div>;
+
+  const columns = [
+    {
+      header: "Name",
+      getBody: (player: Player) => `${player.firstName} ${player.lastName}`,
+    },
+    {
+      header: "Number",
+      getBody: (player: Player) => player.jersey,
+    },
+    {
+      header: "Position",
+      getBody: (player: Player) => player.position,
+    },
+    {
+      header: "DoB",
+      getBody: (player: Player) =>
+        DateTime.fromISO(player.birthDate).toFormat("dd MMM yyyy"),
+    },
+    {
+      header: "Height",
+      getBody: (player: Player) =>
+        `${Math.floor(player.height / 12)}'${Math.floor(player.height % 12)}"`,
+    },
+    {
+      header: "Weight",
+      getBody: (player: Player) => `${player.weight} lbs`,
+    },
+    {
+      header: "College",
+      getBody: (player: Player) => player.college,
+    },
+  ];
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl">{team.name}</h1>
+      {playerList?.players?.length ? (
+        <Table
+          data={playerList?.players}
+          columns={columns}
+          rowLink={(info) => `/player/${info.id}`}
+          orderBy={(player) => {
+            if (!player.jersey) return 999;
+            return Number(player.jersey);
+          }}
+        />
+      ) : (
+        <div> No players </div>
+      )}
+    </div>
+  );
 }

--- a/keelClient.ts
+++ b/keelClient.ts
@@ -225,8 +225,17 @@ export class APIClient extends CoreClient {
     constructor(config: RequestConfig) {
 		super(config);
 	}
+    getPlayer(i: GetPlayerInput) {
+        return this.request<Player | null>("getPlayer", i);
+    }
+    getPlayersOnTeam(i: GetPlayersForTeamProps) {
+        return this.request<GetPlayersForTeamResponse>("getPlayersOnTeam", i);
+    }
     updatePlayersOnTeam(i: UpdatePlayerTeamsProps) {
         return this.request<Any>("updatePlayersOnTeam", i);
+    }
+    getTeam(i: GetTeamInput) {
+        return this.request<Team | null>("getTeam", i);
     }
     getTeams(i?: GetTeamsInput) {
         return this.request<{results: Team[], pageInfo: any}>("getTeams", i);
@@ -256,6 +265,18 @@ export interface UpdateTeamProps {
 export interface UpdatePlayerTeamsProps {
     overrideDateProtection?: boolean | null;
     teamId: string;
+}
+export interface GetPlayersForTeamProps {
+    teamId: string;
+}
+export interface GetPlayersForTeamResponse {
+    players: Player[];
+}
+export interface GetPlayerInput {
+    id: string;
+}
+export interface GetTeamInput {
+    id: string;
 }
 export interface GetTeamsWhere {
 }
@@ -342,6 +363,7 @@ export interface Team {
     name: string
     conference: string
     division: string
+    alias: string | null
     id: string
     createdAt: Date
     updatedAt: Date

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.195",
+    "@types/luxon": "^3.3.0",
     "@types/node": "20.4.2",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.7",
@@ -17,6 +18,7 @@
     "eslint": "8.44.0",
     "eslint-config-next": "13.4.9",
     "lodash": "^4.17.21",
+    "luxon": "^3.3.0",
     "next": "13.4.9",
     "postcss": "8.4.25",
     "react": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,6 +219,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
   integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
 
+"@types/luxon@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.0.tgz#a61043a62c0a72696c73a0a305c544c96501e006"
+  integrity sha512-uKRI5QORDnrGFYgcdAVnHvEIvEZ8noTpP/Bg+HeUzZghwinDlIS87DEenV5r1YoOF9G4x600YsUXLWZ19rmTmg==
+
 "@types/node@20.4.2":
   version "20.4.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.2.tgz#129cc9ae69f93824f92fac653eebfb4812ab4af9"
@@ -1641,6 +1646,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+luxon@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"
+  integrity sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Description
- Add team detail page, showing a list of players on the team, ordered by jersey. 
- Clean up the `Table` code a little
- Add the ability to order by a field in the table

## Recording
https://www.loom.com/share/ea95f1728d1749eb92439f7dbb3a21d0